### PR TITLE
Feature/querying by name

### DIFF
--- a/src/decorators/parse-optional-boolean.decorator.ts
+++ b/src/decorators/parse-optional-boolean.decorator.ts
@@ -1,0 +1,9 @@
+import { Transform } from 'class-transformer';
+
+const optionalBooleanMapper = new Map([
+  ['true', true],
+  ['false', false],
+]);
+
+export const ParseOptionalBoolean = () =>
+  Transform(({ value }) => optionalBooleanMapper.get(value));

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,11 @@ async function bootstrap() {
 
   setupSwagger(app)
 
+  app.enableCors({
+    origin: "*",
+    credentials: true,
+  })
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/todos/dto/create-todo.dto.ts
+++ b/src/todos/dto/create-todo.dto.ts
@@ -1,10 +1,7 @@
-import { IsBoolean, IsDate, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsDate, IsOptional, IsString } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class CreateTodoDto {
-
-  @IsNumber()
-  readonly user: number;
 
   @IsString()
   readonly title: string;

--- a/src/todos/dto/query-options.dto.ts
+++ b/src/todos/dto/query-options.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { PageOptionsDto } from '../../utils/pagination/page-options.dto';
 import { ParseOptionalBoolean } from '../../decorators/parse-optional-boolean.decorator';
 
@@ -9,4 +9,9 @@ export class TodoQueryOptionsDto extends PageOptionsDto {
   @ParseOptionalBoolean()
   @IsOptional()
   readonly done?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  readonly title?: string;
 }

--- a/src/todos/dto/query-options.dto.ts
+++ b/src/todos/dto/query-options.dto.ts
@@ -1,0 +1,12 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+import { PageOptionsDto } from '../../utils/pagination/page-options.dto';
+import { ParseOptionalBoolean } from '../../decorators/parse-optional-boolean.decorator';
+
+export class TodoQueryOptionsDto extends PageOptionsDto {
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @ParseOptionalBoolean()
+  @IsOptional()
+  readonly done?: boolean;
+}

--- a/src/todos/todos.controller.ts
+++ b/src/todos/todos.controller.ts
@@ -15,11 +15,11 @@ import { UpdateTodoDto } from './dto/update-todo.dto';
 import { User } from '../decorators/user.decorator';
 import { User as UserEntity } from '../users/entities/user.entity';
 import { Response } from 'express';
-import { PageOptionsDto } from '../utils/pagination/page-options.dto';
 import { PageDto } from '../utils/pagination/page.dto';
 import { Todo } from './entities/todo.entity';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiPaginatedResponse } from '../decorators/api-tags.decorator';
+import { TodoQueryOptionsDto } from './dto/query-options.dto';
 
 @Controller('todos')
 @ApiTags('Todos')
@@ -36,16 +36,15 @@ export class TodosController {
     return response.status(HttpStatus.CREATED).json(createdTodo);
   }
 
-  @Get(':userId')
+  @Get()
   @ApiPaginatedResponse(Todo)
   async findAllByUserId(
     @Res() response: Response,
-    @Query() pageOptionsDto: PageOptionsDto,
-    @Param('userId') id: string,
+    @Query() QueryDto: TodoQueryOptionsDto,
     @User() user: UserEntity,
   ): Promise<Response<PageDto<Todo>>> {
     const todos =
-      await this.todosService.findAllByUserId(pageOptionsDto, +id, user.id);
+      await this.todosService.findAllByUserId(QueryDto, user.id);
     return response.status(HttpStatus.OK).json(todos);
   }
 

--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -42,7 +42,6 @@ export class TodosService {
     }
     if ('done' in queryOptions) filters['done'] = queryOptions.done;
     if ('title' in queryOptions) {
-      console.log("tem", queryOptions.title);
       const title = queryOptions.title;
       queryBuilder.where({ title: Like(`%${title}%`)  });
     }

--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -3,9 +3,8 @@ import { CreateTodoDto } from './dto/create-todo.dto';
 import { UpdateTodoDto } from './dto/update-todo.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Todo } from './entities/todo.entity';
-import { Repository } from 'typeorm';
+import { Like, Repository } from 'typeorm';
 import { UsersService } from '../users/users.service';
-import { PageOptionsDto } from '../utils/pagination/page-options.dto';
 import { PageMetaDto } from '../utils/pagination/page-meta.dto';
 import { PageDto } from '../utils/pagination/page.dto';
 import { TodoQueryOptionsDto } from './dto/query-options.dto';
@@ -41,10 +40,14 @@ export class TodosService {
     const filters = {
       user: requestingUser,
     }
-    if(queryOptions.done) filters['done'] = queryOptions.done
-    console.log(filters)
+    if ('done' in queryOptions) filters['done'] = queryOptions.done;
+    if ('title' in queryOptions) {
+      console.log("tem", queryOptions.title);
+      const title = queryOptions.title;
+      queryBuilder.where({ title: Like(`%${title}%`)  });
+    }
     queryBuilder
-      .where(filters)
+      .andWhere(filters)
       .orderBy(queryOptions.orderBy, queryOptions.order)
       .skip(queryOptions.skip)
       .take(queryOptions.take)

--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -8,6 +8,7 @@ import { UsersService } from '../users/users.service';
 import { PageOptionsDto } from '../utils/pagination/page-options.dto';
 import { PageMetaDto } from '../utils/pagination/page-meta.dto';
 import { PageDto } from '../utils/pagination/page.dto';
+import { TodoQueryOptionsDto } from './dto/query-options.dto';
 
 @Injectable()
 export class TodosService {
@@ -22,10 +23,8 @@ export class TodosService {
     createTodoDto: CreateTodoDto,
     requestingUser: number
   ): Promise<Todo> {
-    if(requestingUser !== createTodoDto.user)
-      throw new BadRequestException("Trying to create todo for another user.");
 
-    const user = await this.usersService.findOneById(createTodoDto.user);
+    const user = await this.usersService.findOneById(requestingUser);
     const todo = this.todosRepository.create({
       ...createTodoDto,
       user,
@@ -35,22 +34,26 @@ export class TodosService {
   }
 
   async findAllByUserId(
-    pageOptionsDto: PageOptionsDto,
-    userId: number,
+    queryOptions: TodoQueryOptionsDto,
     requestingUser: number): Promise<PageDto<Todo>> {
-    if(requestingUser !== userId )
-      throw new BadRequestException("Trying to see another user todos.");
 
     const queryBuilder = this.todosRepository.createQueryBuilder("todos")
-    queryBuilder.
-      orderBy(pageOptionsDto.orderBy, pageOptionsDto.order)
-      .skip(pageOptionsDto.skip)
-      .take(pageOptionsDto.take)
+    const filters = {
+      user: requestingUser,
+    }
+    if(queryOptions.done) filters['done'] = queryOptions.done
+    console.log(filters)
+    queryBuilder
+      .where(filters)
+      .orderBy(queryOptions.orderBy, queryOptions.order)
+      .skip(queryOptions.skip)
+      .take(queryOptions.take)
 
     const itemCount = await queryBuilder.getCount();
     const { entities } = await queryBuilder.getRawAndEntities()
 
-    const pageMetaDto = new PageMetaDto({ itemCount, pageOptionsDto });
+    const pageMetaDto =
+      new PageMetaDto({ itemCount, pageOptionsDto: queryOptions });
 
     return new PageDto(entities, pageMetaDto)
   }


### PR DESCRIPTION
Não é mais preciso enviar o userId como parâmetro, agora é descoberto a partir do token de autenticação.
Ativando cors para fazer requisições a partir do front-end.
Adicionando a possibilidade de filtrar pelo nome, não precisa ser nome exato.